### PR TITLE
feat: dashboard administrativa com Material UI + Chart.js

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,3 +1,300 @@
-export const DashBoard = ()=>{
-  return <></>
-}
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import PeopleAltRoundedIcon from "@mui/icons-material/PeopleAltRounded";
+import HotelRoundedIcon from "@mui/icons-material/HotelRounded";
+import EventAvailableRoundedIcon from "@mui/icons-material/EventAvailableRounded";
+import PaidRoundedIcon from "@mui/icons-material/PaidRounded";
+import {
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from "chart.js";
+import { Bar, Doughnut } from "react-chartjs-2";
+import {
+  adminService,
+  type BestRes,
+  type QuartoStatsRes,
+  type ReceitaRes,
+  type ReservaRes,
+  type StatsRes,
+} from "../services/adminService";
+import { StatCard } from "./dashboard/StatCard";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, PointElement, Tooltip, Legend);
+
+type DashboardData = {
+  stats: StatsRes;
+  receita: ReceitaRes;
+  quartoStats: QuartoStatsRes;
+  bestQuartos: BestRes[];
+  reservasRecentes: ReservaRes[];
+};
+
+const defaultStats: StatsRes = {
+  totalUsuarios: 0,
+  totalReservas: 0,
+  totalQuartos: 0,
+  reservasAtivos: 0,
+  reservasCanceladas: 0,
+  tavaOcupacao: 0,
+};
+
+const getStatusColor = (status: string): "success" | "warning" | "error" | "info" => {
+  const value = status.toLowerCase();
+  if (value.includes("ativa") || value.includes("confirmada")) return "success";
+  if (value.includes("cancel")) return "error";
+  if (value.includes("pend")) return "warning";
+  return "info";
+};
+
+export const DashBoard = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<DashboardData>({
+    stats: defaultStats,
+    receita: { ativa: 0, canceladas: 0 },
+    quartoStats: { disponiveis: 0, ocupados: 0 },
+    bestQuartos: [],
+    reservasRecentes: [],
+  });
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const [stats, receita, quartoStats, bestQuartos, reservasRecentes] = await Promise.all([
+          adminService.getStats(),
+          adminService.getReceita(),
+          adminService.getQuartoStats(),
+          adminService.getBestQuartos(),
+          adminService.getRecentReservas(),
+        ]);
+
+        setData({ stats, receita, quartoStats, bestQuartos, reservasRecentes: reservasRecentes.slice(0, 8) });
+      } catch {
+        setError("Não foi possível carregar a dashboard administrativa.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void loadData();
+  }, []);
+
+  const reservasChart = useMemo(
+    () => ({
+      labels: ["Ativas", "Canceladas"],
+      datasets: [
+        {
+          label: "Reservas",
+          data: [data.stats.reservasAtivos, data.stats.reservasCanceladas],
+          backgroundColor: ["#22c55e", "#ef4444"],
+          borderRadius: 8,
+        },
+      ],
+    }),
+    [data.stats.reservasAtivos, data.stats.reservasCanceladas],
+  );
+
+  const ocupacaoChart = useMemo(
+    () => ({
+      labels: ["Disponíveis", "Ocupados"],
+      datasets: [
+        {
+          data: [data.quartoStats.disponiveis, data.quartoStats.ocupados],
+          backgroundColor: ["#3b82f6", "#f59e0b"],
+          borderWidth: 0,
+        },
+      ],
+    }),
+    [data.quartoStats.disponiveis, data.quartoStats.ocupados],
+  );
+
+  const bestRoomsChart = useMemo(
+    () => ({
+      labels: data.bestQuartos.map((item) => item.quarto.nome ?? item.quarto.name ?? `Quarto ${item.quarto.id}`),
+      datasets: [
+        {
+          label: "Total de reservas",
+          data: data.bestQuartos.map((item) => item.total),
+          backgroundColor: "#8b5cf6",
+          borderRadius: 8,
+        },
+      ],
+    }),
+    [data.bestQuartos],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ minHeight: "70vh", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 4 }, maxWidth: 1400, mx: "auto" }}>
+      <Stack spacing={1} sx={{ mb: 3 }}>
+        <Typography variant="h4" fontWeight={700}>
+          Dashboard Administrativa
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Visão consolidada de reservas, ocupação e receita do sistema.
+        </Typography>
+      </Stack>
+
+      {error ? (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      ) : null}
+
+      <Grid container spacing={2.5} sx={{ mb: 3 }}>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <StatCard
+            label="Usuários"
+            value={data.stats.totalUsuarios}
+            icon={<PeopleAltRoundedIcon color="primary" />}
+            helper="Total de contas cadastradas"
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <StatCard
+            label="Quartos"
+            value={data.stats.totalQuartos}
+            icon={<HotelRoundedIcon color="primary" />}
+            helper={`Taxa de ocupação: ${data.stats.tavaOcupacao.toFixed(1)}%`}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <StatCard
+            label="Reservas"
+            value={data.stats.totalReservas}
+            icon={<EventAvailableRoundedIcon color="primary" />}
+            helper={`Ativas: ${data.stats.reservasAtivos}`}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <StatCard
+            label="Receita (R$)"
+            value={data.receita.ativa.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+            icon={<PaidRoundedIcon color="primary" />}
+            helper={`Canceladas: R$ ${data.receita.canceladas.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`}
+          />
+        </Grid>
+      </Grid>
+
+      <Grid container spacing={2.5}>
+        <Grid size={{ xs: 12, md: 7 }}>
+          <Card sx={{ borderRadius: 3 }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>
+                Situação das reservas
+              </Typography>
+              <Bar data={reservasChart} options={{ responsive: true, plugins: { legend: { display: false } } }} />
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 5 }}>
+          <Card sx={{ borderRadius: 3 }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>
+                Ocupação de quartos
+              </Typography>
+              <Box sx={{ maxWidth: 340, mx: "auto" }}>
+                <Doughnut data={ocupacaoChart} />
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 6 }}>
+          <Card sx={{ borderRadius: 3, height: "100%" }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>
+                Quartos mais reservados
+              </Typography>
+              {data.bestQuartos.length > 0 ? (
+                <Bar
+                  data={bestRoomsChart}
+                  options={{ indexAxis: "y", responsive: true, plugins: { legend: { display: false } } }}
+                />
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Sem dados de quartos mais reservados.
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 6 }}>
+          <Card sx={{ borderRadius: 3, height: "100%" }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>
+                Reservas recentes
+              </Typography>
+              <Stack spacing={1.5}>
+                {data.reservasRecentes.map((reserva) => (
+                  <Box
+                    key={reserva.id}
+                    sx={{
+                      p: 1.5,
+                      borderRadius: 2,
+                      bgcolor: "action.hover",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      gap: 1,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="subtitle2" fontWeight={700}>
+                        {reserva.usuario.name} • {reserva.quarto.nome ?? reserva.quarto.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {new Date(reserva.data_incio).toLocaleDateString("pt-BR")} - {" "}
+                        {new Date(reserva.data_fim).toLocaleDateString("pt-BR")}
+                      </Typography>
+                    </Box>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography variant="subtitle2" fontWeight={700}>
+                        R$ {reserva.valorTotal.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                      </Typography>
+                      <Chip label={reserva.status} color={getStatusColor(reserva.status)} size="small" />
+                    </Stack>
+                  </Box>
+                ))}
+
+                {data.reservasRecentes.length === 0 ? (
+                  <Typography variant="body2" color="text.secondary">
+                    Nenhuma reserva recente encontrada.
+                  </Typography>
+                ) : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -1,13 +1,34 @@
-import { Card, Typography, Box } from "@mui/material";
-import { type statsRes } from "../../services/adminService";
+import { Card, CardContent, Typography, Box } from "@mui/material";
+import type { ReactNode } from "react";
 
-export const StatCard = (props: statsRes)=> {
-    return (
-      <Box
-      component="section"
-      sx={}
-      >
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  icon?: ReactNode;
+  helper?: string;
+};
 
-      </Box>
-    )
-}
+export const StatCard = ({ label, value, icon, helper }: StatCardProps) => {
+  return (
+    <Card sx={{ borderRadius: 3, height: "100%" }}>
+      <CardContent>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            {label}
+          </Typography>
+          {icon}
+        </Box>
+
+        <Typography variant="h5" fontWeight={700}>
+          {value}
+        </Typography>
+
+        {helper ? (
+          <Typography variant="caption" color="text.secondary">
+            {helper}
+          </Typography>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/services/adminService.tsx
+++ b/src/services/adminService.tsx
@@ -1,76 +1,118 @@
 import { adminApi } from "./api";
 import { TOKEN_KEY } from "../lib/token";
 
-type quartoRes ={
-  id: number,
-  status: string,
-  descricao: string,
-  capacidade: number,
-  name: string,
-  valor: number,
-  tipo: string,
-  data_criacao: string
-}
-type bestRes ={
-  total: number,
-  quarto: quartoRes
-}
-type authorities = {
-  authority: string
-}
-type usuarioRes = {
-  id: number,
-  email: string,
-  password: string,
-  name: string,
-  role: string,
-  data_criado: string,
-  ativo: boolean,
-  authorities: authorities
-}
-type reservaRes = {
-  id: number,
-  status: string,
-  quarto: quartoRes,
-  usuario: usuarioRes,
-  data_incio: string,
-  data_fim: string,
-  valorTotal: number,
-  data_criado: string
-}
-type receitaRes = {
-  ativa: number,
-  canceladas: number
-}
-type receitaPeriodoRes = {
-  dataInicio: string,
-  dataFim: string,
-  receitaAtivas: number,
-  receitaCanceladas: number,
-  receitaTotal: number
-}
-type quartoStatsRes = {
-  disponiveis: number,
-  ocupados: number
-}
-export type statsRes = {
-  totalUsuarios: number,
-  totalReservas: number,
-  totalQuartos: number,
-  reservasAtivos: number,
-  reservasCanceladas: number,
-  tavaOcupacao: number
-}
+export type QuartoRes = {
+  id: number;
+  status: string;
+  descricao: string;
+  capacidade: number;
+  nome?: string;
+  name?: string;
+  valor: number;
+  tipo: string;
+  data_criacao: string;
+};
 
-export function adminService() {
-  const getAllQuartos = async (): Promise<quartoRes[]> => {
-    const token = localStorage.getItem(TOKEN_KEY)
-    const res = await adminApi.get<quartoRes[]>("/quarto",{
-      headers:{
-        Authorization: `Bearer ${token}`
-      }
-    })
+export type BestRes = {
+  total: number;
+  quarto: QuartoRes;
+};
+
+type Authority = {
+  authority: string;
+};
+
+export type UsuarioRes = {
+  id: number;
+  email: string;
+  password: string;
+  name: string;
+  role: string;
+  data_criado: string;
+  ativo: boolean;
+  authorities: Authority;
+};
+
+export type ReservaRes = {
+  id: number;
+  status: string;
+  quarto: QuartoRes;
+  usuario: UsuarioRes;
+  data_incio: string;
+  data_fim: string;
+  valorTotal: number;
+  data_criado: string;
+};
+
+export type ReceitaRes = {
+  ativa: number;
+  canceladas: number;
+};
+
+export type ReceitaPeriodoRes = {
+  dataInicio: string;
+  dataFim: string;
+  receitaAtivas: number;
+  receitaCanceladas: number;
+  receitaTotal: number;
+};
+
+export type QuartoStatsRes = {
+  disponiveis: number;
+  ocupados: number;
+};
+
+export type StatsRes = {
+  totalUsuarios: number;
+  totalReservas: number;
+  totalQuartos: number;
+  reservasAtivos: number;
+  reservasCanceladas: number;
+  tavaOcupacao: number;
+};
+
+const authHeaders = () => ({
+  headers: {
+    Authorization: `Bearer ${localStorage.getItem(TOKEN_KEY)}`,
+  },
+});
+
+export const adminService = {
+  async getAllQuartos(): Promise<QuartoRes[]> {
+    const res = await adminApi.get<QuartoRes[]>("/quarto", authHeaders());
     return res.data;
-  }
+  },
 
-}
+  async getRecentReservas(): Promise<ReservaRes[]> {
+    const res = await adminApi.get<ReservaRes[]>("/reserva", authHeaders());
+    return res.data;
+  },
+
+  async getBestQuartos(): Promise<BestRes[]> {
+    const res = await adminApi.get<BestRes[]>("/quarto/mais-reservados", authHeaders());
+    return res.data;
+  },
+
+  async getReceita(): Promise<ReceitaRes> {
+    const res = await adminApi.get<ReceitaRes>("/receita", authHeaders());
+    return res.data;
+  },
+
+  async getReceitaPeriodo(dataInicio: string, dataFim: string): Promise<ReceitaPeriodoRes> {
+    const res = await adminApi.get<ReceitaPeriodoRes>("/receita/periodo", {
+      ...authHeaders(),
+      params: { dataInicio, dataFim },
+    });
+    return res.data;
+  },
+
+  async getQuartoStats(): Promise<QuartoStatsRes> {
+    const res = await adminApi.get<QuartoStatsRes>("/quarto/stats", authHeaders());
+    return res.data;
+  },
+
+  async getStats(): Promise<StatsRes> {
+    const res = await adminApi.get<StatsRes>("/stats", authHeaders());
+    return res.data;
+  },
+};


### PR DESCRIPTION
### Motivation
- Fornecer uma dashboard administrativa completa consumindo os endpoints do `adminService` para mostrar KPIs, gráficos e reservas recentes usando `Chart.js` e componentes do `Material UI`.
- Centralizar tipos e chamadas administrativas para facilitar o uso dos dados na UI e reduzir duplicação de chamadas HTTP.

### Description
- Reestruturei e exportei um `adminService` consistente em `src/services/adminService.tsx` com tipos fortemente tipados e novos métodos: `getStats`, `getReceita`, `getQuartoStats`, `getBestQuartos`, `getRecentReservas` e utilitário `authHeaders` para autorização.
- Implementei a dashboard em `src/components/Dashboard.tsx` com carregamento assíncrono, tratamento de `loading`/`error`, cartões de KPI e três gráficos (`Bar` e `Doughnut`) via `chart.js` + `react-chartjs-2` e registro dos componentes ChartJS necessários.
- Adicionei um componente reutilizável `StatCard` em `src/components/dashboard/StatCard.tsx` para exibir métricas com `Material UI`.
- Pequenos ajustes de tipagem/nomes (ex.: `QuartoRes.nome`/`name`) para compatibilizar dados retornados pelo backend.

### Testing
- Executado `npx eslint src/components/Dashboard.tsx src/components/dashboard/StatCard.tsx src/services/adminService.tsx` com sucesso (sem erros reportados para os arquivos alterados).
- Iniciado servidor de desenvolvimento com `npm run dev` e foi possível renderizar a página; capture de tela automatizada gerada (artifacts/dashboard.png) confirmando a UI em funcionamento.
- `npm run build` falhou devido a um erro pré-existente não relacionado a esta mudança (`src/components/quartos/QuartoGrid.tsx` reportando uma propriedade `valor` ausente), portanto a build de produção não foi concluída neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e966c9c0832084d69261a5f69e37)